### PR TITLE
Fix column bounds

### DIFF
--- a/R/roi.plugin.cbc.R
+++ b/R/roi.plugin.cbc.R
@@ -34,7 +34,20 @@ solver <- function(x, control) {
   } else {
     is_integer <- rep.int(FALSE, n_cols)
   }
-
+  
+  # build column bounds when they are differents from default in ROI
+  bounds <- bounds(x)
+  lb_ind <- bounds$lower$ind
+  lb_val <- bounds$lower$val
+  ub_ind <- bounds$upper$ind
+  ub_val <- bounds$upper$val
+  if (!is.null(lb_ind)){
+    col_lb[lb_ind] <- lb_val 
+  }
+  if (!is.null(ub_ind)){ 
+    col_ub[ub_ind] <- ub_val
+  }
+  
   # build row bounds
   constraints <- ROI::constraints(x)
   row_dir <- constraints$dir

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -47,3 +47,31 @@ test_that("supports equality constraints", {
   expect_equal(120, result$objval)
   expect_equal(60, result$solution)
 })
+
+test_that("can solve simple IP problem with lower col bounds and lower columns bounds", {
+  IP <- ROI::OP(c(2, 4, 3),
+                ROI::L_constraint(
+                  L = matrix(c(3, 2, 1, 4, 1, 3, 2, 2, 2), nrow = 3),
+                  dir = c("<=", ">=", "<="),
+                  rhs = c(60, 40, 80)),
+                types = c("I", "I", "B"),
+                max = TRUE )
+  bounds(IP) <- V_bound(li=1:3, lb=c(20,-1,1))
+  result <- ROI::ROI_solve(IP, "cbc")
+  expect_equal(39, result$objval)
+  expect_equal(c(20, -1, 1), result$solution)
+})
+
+test_that("can solve simple lp problem with lower row bounds and lower columns bounds", {
+  LP <- ROI::OP(c(2, 4, 3),
+                ROI::L_constraint(
+                  L = matrix(c(3, 2, 1, 4, 1, 3, 2, 2, 2), nrow = 3),
+                  dir = c("<=", ">=", "<="),
+                  rhs = c(60, 40, 80)),
+                max = TRUE )
+  bounds(LP) <- V_bound(li=1:3, lb=c(10,0,0))
+  result <- ROI::ROI_solve(LP, "cbc")
+  expect_equal(65, result$objval)
+  expect_equal(c(10, 0, 15), result$solution)
+})
+


### PR DESCRIPTION
Column bounds were not taken into account and reseted to default when passing the problem to cbc.

With this PR, column bounds from ROI are taken into account by cbc.

https://github.com/dirkschumacher/ROI.plugin.cbc/issues/6#issue-333318331